### PR TITLE
Add support for custom logos

### DIFF
--- a/src/components/Header/Logo.js
+++ b/src/components/Header/Logo.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import logoSrc from '@madetech/marketing-assets/logos/made-tech-logo-colour.png'
+
+export default function Logo ({ width }) {
+  return (
+    <img
+      alt='Made Tech'
+      itemProp='logo'
+      src={logoSrc}
+      width={width || '200px'}
+      />
+  )
+}

--- a/src/components/Header/LogoType.js
+++ b/src/components/Header/LogoType.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Logo from './Logo'
+
+export default function LogoType ({ text }) {
+  const textWithoutSpaces = text.replace(' ', '\u200A')
+
+  return (
+    <div class="d-flex align-items-center">
+      <span class="header_logo_type__text">{textWithoutSpaces}</span>
+      <span class="px-3">by</span>
+      <Logo width='120px' />
+    </div>
+  )
+}

--- a/src/components/Header/_header_logo_type.scss
+++ b/src/components/Header/_header_logo_type.scss
@@ -1,0 +1,9 @@
+.header_logo_type__text {
+  font-family: "neuzeit-gro-bold";
+  font-size: 1.4em;
+  font-weight: normal;
+
+  @media only screen and (max-width: var(--breakpoint-md)) {
+    font-size: 1.8em;
+  }
+}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,14 +1,17 @@
 import React from 'react'
-import logo from '@madetech/marketing-assets/logos/made-tech-logo-colour.png'
+import Logo from './Logo'
+import LogoType from './LogoType'
 import Nav from './Nav'
 
-export default function Header ({ navLinks }) {
+export default function Header ({ logoText, navLinks }) {
+  const logo = logoText ? <LogoType text={logoText} /> : <Logo />
+
   return (
     <header className='header'>
       <div className='header__inner'>
         <div className='navbar navbar-expand-lg p-0'>
           <div className='navbar-brand mr-auto'>
-            <img alt='Made Tech' itemProp='logo' src={logo} width='200px' />
+            {logo}
           </div>
 
           <button

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ function App () {
     <main>
       <Components.TopBar />
       <Components.Header navLinks={<NavLinks />} />
+      <Components.Header logoText='Learn Tech' navLinks={<NavLinks />} />
     </main>
   )
 }

--- a/src/madetech-frontend.scss
+++ b/src/madetech-frontend.scss
@@ -4,5 +4,6 @@
 @import 'shared/fonts';
 @import 'shared/typography';
 @import 'components/Header/header.scss';
+@import 'components/Header/header_logo_type.scss';
 @import 'components/Header/header_nav.scss';
 @import 'components/TopBar/top_bar.scss';


### PR DESCRIPTION
We want to support logos such as “Learn Tech by Made Tech”. Using Neuzeit Grotesk Bold we can replicate the Made Tech logo with custom text.

Example:

![](https://www.dropbox.com/s/qkwr6e9v20gwcws/Screenshot%202018-11-15%2008.13.45.png?raw=1)