### PR TITLE
v5.9.4 - update book link in sitemap to /resources/books

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madetech/frontend",
-  "version": "5.9.3",
+  "version": "5.9.4",
   "description": "A collection of components and resources for creating Made Tech branded sites and applications.",
   "main": "lib/index.js",
   "repository": {

--- a/src/components/SiteMap/index.js
+++ b/src/components/SiteMap/index.js
@@ -34,7 +34,7 @@ export default function SiteMap () {
               <p><strong>Resources</strong></p>
 
               <a href="/blog">Blog</a>
-              <a href="/resources/ebook">E-Books</a>
+              <a href="/resources/books">Books</a>
               <a href="https://learn.madetech.com">Learn Tech</a>
             </nav>
           </div>


### PR DESCRIPTION
**What?**

Updates the link in the sitemap to the new URL for the books. Replaces "E-Books" with just "Books".