### PR TITLE
Update copyright year to always be the current year

### DIFF
--- a/src/components/Footer/footer.test.js
+++ b/src/components/Footer/footer.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Footer from './index';
+
+describe('<Footer>', () => {
+    it('displays the correct copyright year', () => {
+        const wrapper = shallow(<Footer />);
+        const currentYear = new Date().getFullYear();
+        expect(wrapper.find({"data-test": "copyrightYear"}).length).toEqual(1);
+        expect(wrapper.find({"data-test": "copyrightYear"}).text()).toEqual(currentYear.toString());
+    })
+})

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -4,12 +4,13 @@ import twitterSrc from '@madetech/marketing-assets/icons/twitter.svg'
 import githubSrc from '@madetech/marketing-assets/icons/github.svg'
 
 export default function Footer () {
+  const currentYear = new Date().getFullYear();
   return (
     <footer className='footer'>
       <div className='container'>
         <div className='row'>
           <div className='col-12 text-center col-sm-6 text-sm-left d-sm-block footer__copyright_notice'>
-            © <span itemProp='copyrightHolder' itemScope itemType='http://schema.org/Organization'><span itemProp='name'>Made Tech</span></span> <span itemProp='copyrightYear'>2019</span>
+            © <span itemProp='copyrightHolder' itemScope itemType='http://schema.org/Organization'><span itemProp='name'>Made Tech</span></span> <span itemProp='copyrightYear' data-test='copyrightYear'>{currentYear}</span>
             <span> | </span>
             <a href="https://www.madetech.com/privacy">Privacy Policy</a>
           </div>


### PR DESCRIPTION
Previously this would require a manual developer update each year as it is not configurable through contentful.
This change will cause it to update in line with the current year.
A test was also added to check this rendering pulled through correctly.